### PR TITLE
Add simple voice bot prototype

### DIFF
--- a/voicebot/Dockerfile
+++ b/voicebot/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY voicebot.py ./
+
+CMD ["python", "voicebot.py"]

--- a/voicebot/README.md
+++ b/voicebot/README.md
@@ -1,0 +1,46 @@
+# Real-Time English Conversation Bot
+
+This directory contains a sample Python script that demonstrates a very simple real-time conversation bot. It performs the following steps:
+
+1. **Speech recognition** using your microphone.
+2. **Text generation** by sending the recognized text to an API compatible with the Lambda included in this repository.
+3. **Speech synthesis** of the generated reply using `pyttsx3`.
+
+## Requirements
+
+The script depends on a few Python packages. Install them via `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+For Linux users, the `pyaudio` package may require additional system libraries such as `portaudio`.
+
+## Usage
+
+1. Start the script:
+
+```bash
+python voicebot.py
+```
+
+2. Speak into your microphone. The recognized text is sent to the API at `CHAT_API_ENDPOINT` (defaults to `http://localhost:8000/chat`). You can change this endpoint by setting the environment variable before running the script:
+
+```bash
+CHAT_API_ENDPOINT=https://example.com/chat python voicebot.py
+```
+
+3. The bot replies with synthesized speech. Press `Ctrl+C` to exit.
+
+## Docker
+
+A simple Dockerfile is provided. Build and run the container with:
+
+```bash
+docker build -t voicebot .
+docker run --rm -e CHAT_API_ENDPOINT=https://example.com/chat --device /dev/snd voicebot
+```
+
+The container requires access to your audio devices; the exact `--device` options may vary by platform.
+
+This is only a minimal prototype. You can swap the API endpoint with any text generation service and replace `pyttsx3` with a higher quality TTS library for more natural speech output.

--- a/voicebot/requirements.txt
+++ b/voicebot/requirements.txt
@@ -1,0 +1,4 @@
+SpeechRecognition
+pyttsx3
+pyaudio
+requests

--- a/voicebot/voicebot.py
+++ b/voicebot/voicebot.py
@@ -1,0 +1,65 @@
+import os
+import json
+import requests
+import speech_recognition as sr
+import pyttsx3
+
+API_ENDPOINT = os.environ.get("CHAT_API_ENDPOINT", "http://localhost:8000/chat")
+
+
+def recognize_speech(recognizer, microphone):
+    with microphone as source:
+        print("Listening...")
+        recognizer.adjust_for_ambient_noise(source)
+        audio = recognizer.listen(source)
+    try:
+        text = recognizer.recognize_google(audio, language="en-US")
+        print("You:", text)
+        return text
+    except sr.UnknownValueError:
+        print("Sorry, I could not understand the audio.")
+    except sr.RequestError as e:
+        print("Speech recognition error:", e)
+    return None
+
+
+def generate_response(message, history):
+    payload = {"message": message, "conversationHistory": history}
+    try:
+        res = requests.post(API_ENDPOINT, json=payload)
+        res.raise_for_status()
+        data = res.json()
+        if data.get("success"):
+            return data.get("response", "")
+    except Exception as e:
+        print("API error:", e)
+    return "Sorry, I couldn't process that."
+
+
+def speak_text(text):
+    engine = pyttsx3.init()
+    engine.say(text)
+    engine.runAndWait()
+
+
+def main():
+    recognizer = sr.Recognizer()
+    mic = sr.Microphone()
+    history = []
+    print("Start a conversation. Press Ctrl+C to exit.")
+    try:
+        while True:
+            text = recognize_speech(recognizer, mic)
+            if not text:
+                continue
+            history.append({"role": "user", "content": text})
+            response = generate_response(text, history)
+            print("Bot:", response)
+            history.append({"role": "assistant", "content": response})
+            speak_text(response)
+    except KeyboardInterrupt:
+        print("Goodbye!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add voicebot prototype for real-time speech chat
- include requirements and Dockerfile for container usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb52aa488832e95d2620a22d4ecb3